### PR TITLE
Add dependency to RainLab.Translate plugin and fix typo

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -10,6 +10,8 @@ use System\Classes\PluginBase;
 class Plugin extends PluginBase
 {
 
+    public $require = ['RainLab.Translate'];
+
     /**
      * Returns information about this plugin.
      *

--- a/models/Category.php
+++ b/models/Category.php
@@ -13,7 +13,7 @@ class Category extends Model
     use \October\Rain\Database\Traits\Validation;
     use \October\Rain\Database\Traits\NestedTree;
 
-    public $implement = ['@RainLab.Translate.Behaviors.TranslatableModel'];
+    public $implement = ['RainLab.Translate.Behaviors.TranslatableModel'];
 
     /**
      * @var boolean Channel has new posts for member, set by ChannelWatch model


### PR DESCRIPTION
Added dependency to RainLab plugin and fixed typo. Without this plugin wasn't working.
